### PR TITLE
chore: release 1.2.1 to ship advisory version-range filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-actions-lockfile",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "AGPL-3.0-or-later",
   "description": "Generate and verify lockfiles for GitHub Actions dependencies",
   "author": "Garen Torikian",


### PR DESCRIPTION
## Summary

- Bumps version to 1.2.1 so the publish workflow rebuilds `dist/` and cuts a release.
- Ships the advisory version-range filtering from #39, which has been on `main` since 2026-02-09 but was never released — `dist/` was last built for v1.2.0 on 2025-12-23.

## Why

Per #46, SHA-pinned actions trip every advisory regardless of the actual vulnerable range, because the published `dist/index.js` reads `vulnerableVersionRange` from the GraphQL response but never uses it (no `satisfies`, no `normalizeVersion`, no SHA→tag resolution). The fix already exists on `main`; it just needs to ship.

## Test plan

- [ ] Merge triggers `publish.yml` `prepare` job (push to main with `package.json` change), which opens a release PR.
- [ ] Merging the release PR rebuilds `dist/` (`build_dist: true`) and publishes v1.2.1.
- [ ] After release, run `mode: verify` against `azure/setup-kubectl@776406b…` (v4.0.1) and `@829323503…` (v5.1.0) — neither should be flagged for GHSA-p756-rfxh-x63h.

Closes #46